### PR TITLE
fix: overlay animate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contaazul/driver.js",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "A light-weight, no-dependency, vanilla JavaScript library to drive the user's focus across the page",
   "main": "dist/driver.min.js",
   "types": "types/index.d.ts",

--- a/src/core/stage.js
+++ b/src/core/stage.js
@@ -1,4 +1,9 @@
-import { CLASS_STAGE_NO_ANIMATION, ID_STAGE, STAGE_HTML } from '../common/constants';
+import {
+  CLASS_STAGE_NO_ANIMATION,
+  ID_STAGE,
+  STAGE_HTML,
+  ID_OVERLAY,
+} from '../common/constants';
 import { createNodeFromString } from '../common/utils';
 import Element from './element';
 
@@ -79,6 +84,7 @@ export default class Stage extends Element {
 
     const width = (position.right - position.left) + (requiredPadding);
     const height = (position.bottom - position.top) + (requiredPadding);
+    const overlay = this.document.getElementById(ID_OVERLAY);
 
     // Show the stage
     this.node.style.display = 'block';
@@ -88,5 +94,9 @@ export default class Stage extends Element {
     this.node.style.top = `${position.top - (requiredPadding / 2)}px`;
     this.node.style.left = `${position.left - (requiredPadding / 2)}px`;
     this.node.style.backgroundColor = this.options.stageBackground;
+
+    setTimeout(() => {
+      overlay.style.opacity = this.options.animate ? this.options.opacity : 0;
+    });
   }
 }


### PR DESCRIPTION
Para corrigir um [problema relacionado ao position fixed](https://github.com/ContaAzul/ca-components/issues/2414) de um elemento (https://github.com/kamranahmedse/driver.js/issues/241), precisamos adicionar o `animate: false` em um step específico.

Porém, ao setar `animate: false` em um step, o overlay ficava com um background muito escuro.

Por isso, adicionei um if que remove o opacity do overlay quando é informado animate: false no step.

![Kapture 2020-09-14 at 13 00 47](https://user-images.githubusercontent.com/14933454/93109820-e66c5300-f68a-11ea-8143-37ff6101a5f8.gif)
