### PR TITLE
fix: navigation in scrollable elements other than window

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## O quê?
+<!-- 
+    Liste as principais mudanças/impactos
+-->
+
+
+## Por quê?
+<!--  
+    Dê um overview sobre as alterações para quem for revisar o _pull request_ tenha um contexto
+    Caso tenha issue relacionada, adicione "Resolves #XX": onde #XX é o número da issue
+-->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contaazul/driver.js",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "A light-weight, no-dependency, vanilla JavaScript library to drive the user's focus across the page",
   "main": "dist/driver.min.js",
   "types": "types/index.d.ts",

--- a/src/core/element.js
+++ b/src/core/element.js
@@ -81,12 +81,33 @@ export default class Element {
   }
 
   /**
+   * Manually scrolls to the position of element if `container` options was informed
+   * This helps to improve scroll experience to containers different from window
+   * @private
+   */
+  scrollContainerManually() {
+    const elementRect = this.node.getBoundingClientRect();
+    const containerRect = this.options.container.getBoundingClientRect();
+
+    const absoluteElementTop = elementRect.top + this.options.container.scrollTop;
+    const height = absoluteElementTop - (containerRect.height / 2);
+
+    this.options.container.scrollTo(0, height);
+  }
+
+  /**
    * Brings the element to middle of the view port if not in view
    * @public
    */
   bringInView() {
     // If the node is not there or already is in view
     if (!this.node || this.isInView()) {
+      return;
+    }
+
+    // If tour is inside a container different from window
+    if (this.options.container) {
+      this.scrollContainerManually();
       return;
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ export default class Driver {
    */
   constructor(options = {}) {
     this.options = {
+      container: null, // Whether tour will be inside a container different from window
       animate: SHOULD_ANIMATE_OVERLAY, // Whether to animate or not
       opacity: OVERLAY_OPACITY,    // Overlay opacity
       padding: OVERLAY_PADDING,    // Spacing around the element from the overlay


### PR DESCRIPTION
## O quê?
- Adicionado nova propriedade `container` para ser utilizada como referência quando tivermos navegação fora da window.

## Por quê?
- Resolves [#1046](https://github.com/ContaAzul/ca-design-system/issues/1046)
